### PR TITLE
Modificación de URL de Redireccionamiento

### DIFF
--- a/docker_dev/run_composer.sh
+++ b/docker_dev/run_composer.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+docker exec -it siep-auth-php chmod 777 ./storage -R
+docker exec -it siep-auth-php composer install
+


### PR DESCRIPTION
Cambio en URL de redireccionamiento para PWA:
- Versión anterior "inscribitepor.sieptdf.org"; Nueva versión "familiares.sieptdf.org".

Los cambios aplican tambien para el servidor de desarrollo